### PR TITLE
Adds TokenizationTaskRequest and InfoService

### DIFF
--- a/fmaas-router/build.rs
+++ b/fmaas-router/build.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .out_dir("src/pb")
         .include_file("mod.rs")
         .compile(
-            &["../proto/generation.proto", "../proto/caikit_runtime_Nlp.proto"],
+            &["../proto/generation.proto", "../proto/caikit_runtime_Nlp.proto", "../proto/caikit_runtime_info.proto"],
             &["../proto"],
         )
         .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));

--- a/fmaas-router/src/rpc.rs
+++ b/fmaas-router/src/rpc.rs
@@ -1,2 +1,25 @@
 pub mod generation;
 pub mod nlp;
+pub mod info;
+
+use tonic::{Code, Request, Status};
+
+
+const METADATA_NAME_MODEL_ID: &str = "mm-model-id";
+
+/// Extracts model_id from [`Request`] metadata.
+fn extract_model_id<T>(request: &Request<T>) -> Result<&str, Status> {
+    let metadata = request.metadata();
+    if !metadata.contains_key(METADATA_NAME_MODEL_ID) {
+        return Err(Status::new(
+            Code::InvalidArgument,
+            "Missing required model ID",
+        ));
+    }
+    let model_id = metadata
+        .get(METADATA_NAME_MODEL_ID)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    Ok(model_id)
+}

--- a/fmaas-router/src/rpc/info.rs
+++ b/fmaas-router/src/rpc/info.rs
@@ -47,30 +47,30 @@ impl InfoServicer {
 
 #[tonic::async_trait]
 impl InfoService for InfoServicer {
-#[instrument(skip_all)]
-async fn get_models_info(
-    &self,
-    request: Request<ModelInfoRequest>,
-) -> Result<Response<ModelInfoResponse>, Status> {
-    let model_id = extract_model_id(&request)?;
-    let mir: &ModelInfoRequest = request.get_ref();
-    if mir.model_ids.is_empty() {
-        return Ok(Response::new(ModelInfoResponse::default()));
+    #[instrument(skip_all)]
+    async fn get_models_info(
+        &self,
+        request: Request<ModelInfoRequest>,
+    ) -> Result<Response<ModelInfoResponse>, Status> {
+        let model_id = extract_model_id(&request)?;
+        let mir: &ModelInfoRequest = request.get_ref();
+        if mir.model_ids.is_empty() {
+            return Ok(Response::new(ModelInfoResponse::default()));
+        }
+        debug!(
+            "Routing get models info request for Model ID {}",
+            model_id
+        );
+        self.client(model_id)
+            .await?
+            .get_models_info(request)
+            .await
     }
-    debug!(
-        "Routing get models info request for Model ID {}",
-        model_id
-    );
-    self.client(model_id)
-        .await?
-        .get_models_info(request)
-        .await
-}
-#[instrument(skip_all)]
-async fn get_runtime_info(
-    &self,
-    _request: Request<RuntimeInfoRequest>,
-) -> Result<Response<RuntimeInfoResponse>, Status> {
-    Err(Status::unimplemented("not implemented"))
-}
+    #[instrument(skip_all)]
+    async fn get_runtime_info(
+        &self,
+        _request: Request<RuntimeInfoRequest>,
+    ) -> Result<Response<RuntimeInfoResponse>, Status> {
+        Err(Status::unimplemented("not implemented"))
+    }
 }

--- a/fmaas-router/src/rpc/info.rs
+++ b/fmaas-router/src/rpc/info.rs
@@ -1,0 +1,76 @@
+use std::collections::HashMap;
+
+use ginepro::LoadBalancedChannel;
+use tonic::{transport::ClientTlsConfig, Request, Response, Status};
+use tracing::{debug, instrument};
+
+use crate::rpc::extract_model_id;
+
+use crate::{create_clients, pb::{
+    caikit::runtime::info::{
+        info_service_client::InfoServiceClient, info_service_server::InfoService
+    },
+    caikit_data_model::common::runtime::{
+        ModelInfoRequest, ModelInfoResponse, RuntimeInfoRequest, RuntimeInfoResponse
+    }
+}, ServiceAddr};
+
+
+#[derive(Debug, Default)]
+pub struct InfoServicer {
+    clients: HashMap<String, InfoServiceClient<LoadBalancedChannel>>,
+}
+
+impl InfoServicer {
+    pub async fn new(
+        default_target_port: u16,
+        client_tls: Option<&ClientTlsConfig>,
+        model_map: &HashMap<String, ServiceAddr>,
+    ) -> Self {
+        let clients = create_clients(
+            default_target_port, client_tls, model_map, InfoServiceClient::new
+        ).await;
+        Self { clients }
+    }
+
+    async fn client(
+        &self,
+        model_id: &str,
+    ) -> Result<InfoServiceClient<LoadBalancedChannel>, Status> {
+        Ok(self
+            .clients
+            .get(model_id)
+            .ok_or_else(|| Status::not_found(format!("Unrecognized model_id: {model_id}")))?
+            .clone())
+    }
+}
+
+#[tonic::async_trait]
+impl InfoService for InfoServicer {
+#[instrument(skip_all)]
+async fn get_models_info(
+    &self,
+    request: Request<ModelInfoRequest>,
+) -> Result<Response<ModelInfoResponse>, Status> {
+    let model_id = extract_model_id(&request)?;
+    let mir: &ModelInfoRequest = request.get_ref();
+    if mir.model_ids.is_empty() {
+        return Ok(Response::new(ModelInfoResponse::default()));
+    }
+    debug!(
+        "Routing get models info request for Model ID {}",
+        model_id
+    );
+    self.client(model_id)
+        .await?
+        .get_models_info(request)
+        .await
+}
+#[instrument(skip_all)]
+async fn get_runtime_info(
+    &self,
+    _request: Request<RuntimeInfoRequest>,
+) -> Result<Response<RuntimeInfoResponse>, Status> {
+    Err(Status::unimplemented("not implemented"))
+}
+}

--- a/fmaas-router/src/server.rs
+++ b/fmaas-router/src/server.rs
@@ -11,8 +11,9 @@ use crate::{
     pb::{
         caikit::runtime::nlp::nlp_service_server::NlpServiceServer,
         fmaas::generation_service_server::GenerationServiceServer,
+        caikit::runtime::info::info_service_server::InfoServiceServer
     },
-    rpc::{generation::GenerationServicer, nlp::NlpServicer},
+    rpc::{generation::GenerationServicer, info::InfoServicer, nlp::NlpServicer},
     ModelMap,
 };
 
@@ -72,6 +73,10 @@ pub async fn run(
         let nlp_servicer =
             NlpServicer::new(default_target_port, client_tls.as_ref(), model_map).await;
         routes_builder.add_service(NlpServiceServer::new(nlp_servicer));
+        info!("Enabling InfoService");
+        let info_servicer =
+        InfoServicer::new(default_target_port, client_tls.as_ref(), model_map).await;
+        routes_builder.add_service(InfoServiceServer::new(info_servicer));
     }
     let grpc_server = builder
         .add_routes(routes_builder.routes())

--- a/proto/caikit_data_model_common_runtime.proto
+++ b/proto/caikit_data_model_common_runtime.proto
@@ -6,7 +6,7 @@
 syntax = "proto3";
 package caikit_data_model.common.runtime;
 import "caikit_data_model_common.proto";
-
+import "google/protobuf/struct.proto";
 
 /*-- MESSAGES ----------------------------------------------------------------*/
 
@@ -18,7 +18,7 @@ message ModelInfo {
   string model_path = 1;
   string name = 2;
   int64 size = 3;
-  map<string, string> metadata = 4;
+  google.protobuf.Struct metadata = 4;
   bool loaded = 7;
   string module_id = 5;
   map<string, string> module_metadata = 6;

--- a/proto/caikit_runtime_Nlp.proto
+++ b/proto/caikit_runtime_Nlp.proto
@@ -201,6 +201,12 @@ message TokenClassificationTaskRequest {
   optional double threshold = 2;
 }
 
+message TokenizationTaskRequest {
+
+  /*-- fields --*/
+  string text = 1;
+}
+
 
 /*-- SERVICES ----------------------------------------------------------------*/
 
@@ -216,6 +222,7 @@ service NlpService {
   rpc TextClassificationTaskPredict(caikit.runtime.Nlp.TextClassificationTaskRequest) returns (caikit_data_model.nlp.ClassificationResults);
   rpc TextGenerationTaskPredict(caikit.runtime.Nlp.TextGenerationTaskRequest) returns (caikit_data_model.nlp.GeneratedTextResult);
   rpc TokenClassificationTaskPredict(caikit.runtime.Nlp.TokenClassificationTaskRequest) returns (caikit_data_model.nlp.TokenClassificationResults);
+  rpc TokenizationTaskPredict(caikit.runtime.Nlp.TokenizationTaskRequest) returns (caikit_data_model.nlp.TokenizationResults);
 }
 
 service NlpTrainingService {


### PR DESCRIPTION
This includes the `TokenizationTaskRequest` method for the embeddings models at the `NLP` interface + implements the `InfoService` for the watsonx product team requirement to be able to retrieve embeddings models' metadata. 

- Implements tokenization_task_predict method for NlpServicer;
- Implements InfoServicer with get_models_info method;